### PR TITLE
Separate "DEBUG" from settings.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-palautekooderit/palautekooderit/secretKey.py
+palautekooderit/palautekooderit/untrackedSettings.py
 *.pyc
 palautekooderit/db.sqlite3

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ windows, with multiple pythons installed
 debian
 > sudo apt install python3-django python3-django-extensions
 2. Clone the repo
-3. change palautekooderit/palautekooderit/secretKey_template.py to palautekooderit/palautekooderit/secretKey.py and fill it.
+3. change palautekooderit/palautekooderit/untrackedSettings_tempate.py to palautekooderit/palautekooderit/untrackedSettings.py and fill it.
     - If you are one of us, you can grab the key, or the entire file, from the server.
 4. Profit???
 

--- a/palautekooderit/palautekooderit/settings.py
+++ b/palautekooderit/palautekooderit/settings.py
@@ -11,8 +11,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
-from .secretKey import SECRET_KEY
-import os
+from .untrackedSettings import SECRET_KEY, DEBUG
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -20,9 +19,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
 
 ALLOWED_HOSTS = ["4.235.120.83", "ankkapeli.fi", "127.0.0.1", "localhost"]
 

--- a/palautekooderit/palautekooderit/untrackedSettings_tempate.py
+++ b/palautekooderit/palautekooderit/untrackedSettings_tempate.py
@@ -1,2 +1,5 @@
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG=False
+
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'SECRET KEY HERE :)'


### PR DESCRIPTION
After these changes, instead of `secretKey.py` we use `untrackedSettings.py`, which additionally has the `DEBUG` variable.

This is done so that we can set the debug to true locally and not have to worry about committing it. 

## ***ATTENTION***
After this change you must "delete" `secretKey.py`, more so moving the key from inside it to `untrackedSettings.py`. ***IT IS VERY IMPORTANT NOT TO ACCIDENTALLY COMMIT THE SECRETKEY**